### PR TITLE
Db settings

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,6 +1,6 @@
 require("dotenv").config();
 const TOKEN= process.env.TOKEN;
-const { Client, Collection, GatewayIntentBits } = require("discord.js");
+const { Client, Collection, GatewayIntentBits, Partials } = require("discord.js");
 const fs = require("fs");
 
 const client = new Client({ 
@@ -11,6 +11,7 @@ const client = new Client({
     GatewayIntentBits.MessageContent,
     GatewayIntentBits.DirectMessages,
   ],
+  partials: [Partials.GuildMember]
   });
 
 client.commands = new Collection();

--- a/src/commands/tools/join.js
+++ b/src/commands/tools/join.js
@@ -13,7 +13,7 @@ module.exports = {
     .setDescription("Join GOF embed")
     .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
   async execute(interaction, client) {
-    const channelID = '918575240651624508' //#join-gof
+    const channelID = process.env.JOIN_GOF //#join-gof
     const channel = interaction.guild.channels.cache.get(channelID)
     const join = new ButtonBuilder()
       .setCustomId("join-us")

--- a/src/components/buttons/join-us.js
+++ b/src/components/buttons/join-us.js
@@ -1,6 +1,6 @@
 const { Guilds, EmbedBuilder } = require("discord.js");
-const PROSPECT = '960908800787882004'
-const GARRI = '758397862399836260'
+const PROSPECT = process.env.PROSPECTS_R
+const GARRI = process.env.GARRI_R
 module.exports = {
     data: {
         name: `join-us`
@@ -10,12 +10,12 @@ module.exports = {
             const buttonID = interaction.customId;
             if (buttonID === 'join-us') { // get button by customId set below
                 const member = interaction.member; // get member from the interaction - person who clicked the button
-                const channelID = '1019418308350595122' //prospects
+                const channelID = process.env.PROSPECTS_C //prospects
                 const channel = interaction.guild.channels.cache.get(channelID)
                 //console.log(member);
                 const leftembed = new EmbedBuilder()
                 .setTitle(`Prospect Notification`)
-                .setDescription(`<@${interaction.user.id}> just removed the <@&${PROSPECT}> role!`)
+                .setDescription(`${member.displayName} just removed the <@&${PROSPECT}> role!`)
                 .setColor(0x800080)
                 .setFooter({
                 iconURL:
@@ -24,7 +24,7 @@ module.exports = {
               })
               const prospectembed = new EmbedBuilder()
               .setTitle(`Prospect Notification`)
-              .setDescription(`<@${interaction.user.id}> just picked up the <@&${PROSPECT}> role!`)
+              .setDescription(`${member.displayName} just picked up the <@&${PROSPECT}> role!`)
               .setColor(0x800080)
               .setFooter({
               iconURL:

--- a/src/events/client/gainGarriRole.js
+++ b/src/events/client/gainGarriRole.js
@@ -1,0 +1,30 @@
+const { EmbedBuilder } = require('discord.js')
+
+module.exports = {
+  name: `guildMemberUpdate`,
+  async execute(oldMember, newMember, client) {
+
+    const roleID = process.env.GARRI_R
+    const channelID = process.env.ADMIN_C
+
+    if(oldMember.roles.cache.has(roleID)) return;
+    if(newMember.roles.cache.has(roleID)){
+
+      const addembed = new EmbedBuilder()
+        .setTitle(`Garri Role Granted`)
+        .setDescription(`<@${newMember.id}> just gained the <@&${roleID}> role.`)
+        .setColor(0x800080)
+        .setFooter({
+          iconURL:
+            "https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/907a507d-e421-4e1c-a7f9-a27a30cabd66/df2hcd0-4292b6df-74b3-4eff-a649-3e4b319300c9.png?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcLzkwN2E1MDdkLWU0MjEtNGUxYy1hN2Y5LWEyN2EzMGNhYmQ2NlwvZGYyaGNkMC00MjkyYjZkZi03NGIzLTRlZmYtYTY0OS0zZTRiMzE5MzAwYzkucG5nIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.9hE9xeqK_NrJDA02KEXxPUatldwFFQakkgpD0rSmIag",
+          text: "Powered by Stark Industries"
+        })
+
+      const channel = newMember.guild.channels.cache.get(channelID)
+
+      //channel.send(`<@${interaction.user.id}>`)
+      channel.send({ content: null, embeds: [addembed], ephemeral: false })
+    
+    }
+  },
+};


### PR DESCRIPTION
Reimplemented name based prospect notis and garri role notis on previous file structure:

NOTE: You will need to replace the process.env.<VAR> in the following files join.js, join-us.js, gainGarriRole.js OR you can add the proper variables to the .env file: The ids below are for the dev server

JOIN_GOF = "1066765661159817327"
PROSPECTS_C = "1068929888402280568"
PROSPECTS_R = "997972309732237462"
GARRI_R = "1066765029841584160"
ADMIN_C = "1066765316274790561"